### PR TITLE
fix: ci setting tune up

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -20,11 +20,6 @@ jobs:
         with:
           path: target
           ref: gh-pages
-      - name: Setup Vim
-        uses: thinca/action-setup-vim@v1
-        with:
-          vim_version: 'v8.2.0020'
-          vim_type: 'Vim'
       - name: Generate new document
         run: |
           cd work

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -39,4 +39,4 @@ jobs:
 
             https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           branch: gh-pages
-          pull_strategy: '--rebase'
+          pull_strategy: 'NO-PULL'

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-  workflow_dispatch:
   schedule:
     - cron: '5 12 * * *'
 
@@ -40,5 +39,4 @@ jobs:
 
             https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           branch: gh-pages
-        env:
-          GITHUB_TOKEN: ${{ secrets.VIMDOC_JP_TOKEN }}
+          pull_strategy: '--rebase'


### PR DESCRIPTION
fix below

rel #15 
close https://github.com/vim-jp/vimdoc-en/issues/16

- remove workflow_dispatch
- remove vim setup / use env default
- remove miss GITHUB_TOKEN env
- add pull_strategy : not need pull (NO-PULL)
  if not NO-PULL set(default), unstage file conflict and fail commit