### PR TITLE
Revert "ci: use default vim"

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           path: target
           ref: gh-pages
+      - name: Setup Vim
+        uses: thinca/action-setup-vim@v1
+        with:
+          vim_version: 'v8.2.0020'
+          vim_type: 'Vim'
       - name: Generate new document
         run: |
           cd work


### PR DESCRIPTION
This reverts commit 2a02ea88bdf8524170be5cfef8e99a7d6f1796f7.

Fix "default env vim TOHtml bug"

see
https://github.com/vim-jp/vimdoc-en/pull/17#issuecomment-826100128