### PR TITLE
Avoid GHA workflow being automatically stopped

### DIFF
--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -1,0 +1,17 @@
+name: Trigger new build
+on:
+  schedule:
+    - cron: '15 11 3 * *'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout master
+        uses: actions/checkout@v2
+      - name: Create an empty commit and push it
+        run: |
+          git config --local user.name 'github-actions'
+          git config --local user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit --allow-empty -m 'Trigger a new build'
+          git push origin master

--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -1,4 +1,4 @@
-name: Trigger new build
+name: Enable each workflow
 on:
   schedule:
     - cron: '15 11 3 * *'
@@ -7,11 +7,13 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout master
-        uses: actions/checkout@v2
-      - name: Create an empty commit and push it
+      - name: Enable each workflow
         run: |
-          git config --local user.name 'github-actions'
-          git config --local user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git commit --allow-empty -m 'Trigger a new build'
-          git push origin master
+          curl -i -X PUT \
+            -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H "Accept: application/vnd.github.v3+json" \
+               'https://api.github.com/repos/vim-jp/vimdoc-en/actions/workflows/generate.yml/enable'
+          curl -i -X PUT \
+            -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H "Accept: application/vnd.github.v3+json" \
+               'https://api.github.com/repos/vim-jp/vimdoc-en/actions/workflows/trigger.yml/enable'


### PR DESCRIPTION
~~Add an empty commit to the master branch once a month.~~
Call the API to enable each workflow once a month: https://docs.github.com/ja/rest/reference/actions#enable-a-workflow

See #22